### PR TITLE
refactor(router): drop code which use old vue-router api

### DIFF
--- a/src/Commands/stubs/vue/router/index.stub
+++ b/src/Commands/stubs/vue/router/index.stub
@@ -65,7 +65,6 @@ const routes = [
 const router = new VueRouter({
     routes,
     mode: 'history',
-    saveScrollPosition: false,
     linkActiveClass: 'active',
     scrollBehavior() {
         return {


### PR DESCRIPTION
https://vuejs.org/v2/guide/migration-vue-router.html#saveScrollPosition-replaced

saveScrollPosition option was deleted since ~0.7 version of vue-router